### PR TITLE
Fix for arm mac processors

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 # Base image which includes common settings
 # and software installation *only*.
 
-FROM ubuntu:20.04
+FROM --platform=linux/x86_64 ubuntu:20.04
 
 ENV TZ=Europe/Moscow
 


### PR DESCRIPTION
С параметрами добавленными в PR сборка нормально происходит на Arm процессорах на Mac. Предполагаю, что при этом они не мешают сборке на других платформах, но не могу проверить. 

Без этих правок у при сборке на M2 возникает ошибка
```
ERROR: failed to solve: ubuntu:20.04: no match for platform in manifest sha256:33a5cc25d22c45900796a1aca487ad7a7cb09f09ea00b779e3b2026b4fc2faba: not found
```